### PR TITLE
Added a way to pass extra argumens for STAR command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,8 @@ jobs:
                         data/test/fastqs/smartseq/smartseq_example.manifest.tsv \
                         --ref data/test/reference/index \
                         --no-bam \
-                        --cpus 1
+                        --cpus 1 \
+                        -- --winAnchorMultimapNmax 50
                 else
                     bin/starsolo $technology \
                         data/test/fastqs/${technology} \
@@ -51,7 +52,8 @@ jobs:
                         --ref data/test/reference/index \
                         --whitelist-dir data/test/whitelists \
                         --no-bam \
-                        --cpus 1
+                        --cpus 1 \
+                        -- --winAnchorMultimapNmax 50
                 fi
     
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ starsolo <platform> <args…> [options]
 | `--no-bam` | Suppress BAM output (default) | ✅ |
 | `-h, --help` | Show help (global or per-platform) | — |
 | `--version` | Print version | — |
+| `--` | Pass all following arguments verbatim to `STAR` | — |
+
+### Passing extra options to STAR
+
+Any arguments after a `--` sentinel are passed verbatim to the underlying `STAR`
+command, appended after the built-in flags. This works on every platform and lets
+you override defaults or set options the CLI doesn't expose:
+
+```bash
+starsolo 10x /data/fastqs SAMPLE1 --species human -- --outFilterScoreMin 20 --soloFeatures Gene GeneFull SJ
+```
+
+The `--` must come last, after all `starsolo` options. Because passthrough
+arguments are appended after the built-in flags, `STAR` will error if a passed
+option is incompatible with one the CLI already sets.
 
 ### 10x Genomics
 

--- a/README.md
+++ b/README.md
@@ -99,9 +99,16 @@ you override defaults or set options the CLI doesn't expose:
 starsolo 10x /data/fastqs SAMPLE1 --species human -- --outFilterScoreMin 20 --soloFeatures Gene GeneFull SJ
 ```
 
-The `--` must come last, after all `starsolo` options. Because passthrough
-arguments are appended after the built-in flags, `STAR` will error if a passed
-option is incompatible with one the CLI already sets.
+The `--` must come last, after all `starsolo` options.
+
+**Overriding built-in flags.** Passthrough arguments are appended *after* the
+flags the CLI sets. STAR uses the last occurrence of a repeated parameter, so a
+passthrough flag overrides the built-in value of the same name — e.g.
+`-- --outFilterScoreMin 20` replaces the default `--outFilterScoreMin 30`. For
+multi-value parameters this is a full replacement, not a merge:
+`-- --soloFeatures Gene GeneFull SJ` replaces the built-in feature list
+entirely. (The parameter does appear twice on the resulting command line; this
+is expected and harmless.)
 
 ### 10x Genomics
 

--- a/bin/starsolo
+++ b/bin/starsolo
@@ -2,7 +2,7 @@
 # =============================================================================
 # starsolo — unified CLI for STARsolo scRNA-seq processing
 # =============================================================================
-# Version 4.0
+# Version 4.2
 #
 # Usage:  starsolo <platform> [args…]
 #         starsolo --help
@@ -12,7 +12,7 @@
 
 set -euo pipefail
 
-STARSOLO_VERSION="4.0"
+STARSOLO_VERSION="4.2"
 
 # ---------- Resolve install paths -------------------------------------------
 
@@ -72,6 +72,8 @@ Global options (available for all platforms):
   --no-bam                  No BAM output (default)
   -h, --help                Show help (per-platform if after platform name)
   --version                 Print version
+  --                        Pass all following arguments verbatim to STAR
+                             (must come last; appended after built-in flags)
 
 Configuration:
   Defaults are read from $STARSOLO_ROOT/etc/defaults.conf
@@ -87,6 +89,7 @@ Examples:
   starsolo indrops /data/fastqs SAMPLE1 --species human --adapter GAGTGATTGCTTGTGACGCCAA
   starsolo strt /data/fastqs SAMPLE1 --species human --strand Reverse
   starsolo qc sample1/ sample2/ --species human
+  starsolo 10x /data/fastqs SAMPLE1 --species human -- --outFilterScoreMin 20 --soloFeatures Gene GeneFull SJ
 EOF
 }
 
@@ -114,6 +117,9 @@ parse_droplet_args() {
     # Platform-specific defaults
     ADAPTER="GAGTGATTGCTTGTGACGCCTT"   # indrops
     STRAND="Forward"                    # strt
+
+    # Extra args passed verbatim to STAR (global array, read by run_* functions)
+    STAR_EXTRA_ARGS=()
 
     # Consume positional args first (up to 2)
     local POSITIONALS=()
@@ -180,6 +186,10 @@ parse_droplet_args() {
             -h|--help)
                 "show_${PLATFORM}_help"
                 exit 0 ;;
+            --)
+                # Everything after '--' is passed verbatim to STAR.
+                STAR_EXTRA_ARGS=("${FLAGS[@]:$((j+1))}")
+                break ;;
             *)
                 die "Unknown option: ${FLAGS[$j]}. Run 'starsolo $PLATFORM --help'." ;;
         esac

--- a/lib/platform_10x.sh
+++ b/lib/platform_10x.sh
@@ -244,7 +244,8 @@ run_10x() {
             --outFilterScoreMin 30 --genomeLoad LoadAndRemove \
             --soloFeatures Gene GeneFull Velocyto \
             --soloOutFileNames "$SOLOFILENAMES" features.tsv barcodes.tsv matrix.mtx \
-            --soloMultiMappers EM --outReadsUnmapped Fastx
+            --soloMultiMappers EM --outReadsUnmapped Fastx \
+            "${STAR_EXTRA_ARGS[@]}"
     else
         STAR --runThreadN "$CPUS" --genomeDir "$REF" \
             --readFilesIn "$R2" "$R1" --runDirPerm All_RWX $GZIP $BAM \
@@ -256,7 +257,8 @@ run_10x() {
             --clipAdapterType CellRanger4 --outFilterScoreMin 30 --genomeLoad LoadAndRemove \
             --soloFeatures Gene GeneFull Velocyto \
             --soloOutFileNames "$SOLOFILENAMES" features.tsv barcodes.tsv matrix.mtx \
-            --soloMultiMappers EM --outReadsUnmapped Fastx
+            --soloMultiMappers EM --outReadsUnmapped Fastx \
+            "${STAR_EXTRA_ARGS[@]}"
     fi
 
     # 8. Cleanup & compress
@@ -285,6 +287,7 @@ Options:
   -c, --cpus <N>            Number of threads             [default: 16]
   --bam                     Output sorted BAM file
   --no-bam                  Do not output BAM (default)
+  --                        Pass all following arguments verbatim to STAR
   -h, --help                Show this help
 EOF
 }

--- a/lib/platform_dropseq.sh
+++ b/lib/platform_dropseq.sh
@@ -36,7 +36,8 @@ run_dropseq() {
         --soloBarcodeReadLength 0 \
         --soloFeatures Gene GeneFull \
         --soloOutFileNames output/ features.tsv barcodes.tsv matrix.mtx \
-        --outReadsUnmapped Fastx
+        --outReadsUnmapped Fastx \
+        "${STAR_EXTRA_ARGS[@]}"
 
     process_output_files "output"
 }
@@ -57,6 +58,7 @@ Options:
   -c, --cpus <N>            Number of threads             [default: 16]
   --bam                     Output sorted BAM file
   --no-bam                  Do not output BAM (default)
+  --                        Pass all following arguments verbatim to STAR
   -h, --help                Show this help
 EOF
 }

--- a/lib/platform_indrops.sh
+++ b/lib/platform_indrops.sh
@@ -47,7 +47,8 @@ run_indrops() {
         --soloUMIposition 3_9_3_14 \
         --soloFeatures Gene GeneFull \
         --soloOutFileNames output/ features.tsv barcodes.tsv matrix.mtx \
-        --outReadsUnmapped Fastx
+        --outReadsUnmapped Fastx \
+        "${STAR_EXTRA_ARGS[@]}"
 
     process_output_files "output"
 }
@@ -74,6 +75,7 @@ Options:
                              [default: GAGTGATTGCTTGTGACGCCTT]
   --bam                     Output sorted BAM file
   --no-bam                  Do not output BAM (default)
+  --                        Pass all following arguments verbatim to STAR
   -h, --help                Show this help
 EOF
 }

--- a/lib/platform_rhapsody.sh
+++ b/lib/platform_rhapsody.sh
@@ -49,7 +49,8 @@ run_rhapsody() {
         --soloUMIposition 0_52_0_59 \
         --soloFeatures Gene GeneFull \
         --soloOutFileNames output/ features.tsv barcodes.tsv matrix.mtx \
-        --outReadsUnmapped Fastx
+        --outReadsUnmapped Fastx \
+        "${STAR_EXTRA_ARGS[@]}"
 
     process_output_files "output"
 }
@@ -74,6 +75,7 @@ Options:
   -c, --cpus <N>            Number of threads             [default: 16]
   --bam                     Output sorted BAM file
   --no-bam                  Do not output BAM (default)
+  --                        Pass all following arguments verbatim to STAR
   -h, --help                Show this help
 EOF
 }

--- a/lib/platform_smartseq.sh
+++ b/lib/platform_smartseq.sh
@@ -47,7 +47,8 @@ run_smartseq() {
         --limitOutSJcollapsed 10000000 --soloCellFilter None \
         --soloFeatures Gene GeneFull \
         --soloOutFileNames output/ features.tsv barcodes.tsv matrix.mtx \
-        --outReadsUnmapped Fastx
+        --outReadsUnmapped Fastx \
+        "${STAR_EXTRA_ARGS[@]}"
 
     rm -f "$NEW_MANIFEST"
     process_output_files "output"
@@ -72,6 +73,7 @@ Options:
   -c, --cpus <N>            Number of threads             [default: 16]
   --bam                     Output sorted BAM file
   --no-bam                  Do not output BAM (default)
+  --                        Pass all following arguments verbatim to STAR
   -h, --help                Show this help
 EOF
 }

--- a/lib/platform_strt.sh
+++ b/lib/platform_strt.sh
@@ -49,7 +49,8 @@ run_strt() {
         --limitOutSJcollapsed 10000000 --soloCellFilter None \
         --soloFeatures Gene GeneFull \
         --soloOutFileNames output/ features.tsv barcodes.tsv matrix.mtx \
-        --outReadsUnmapped Fastx
+        --outReadsUnmapped Fastx \
+        "${STAR_EXTRA_ARGS[@]}"
 
     process_output_files "output"
 }
@@ -74,6 +75,7 @@ Options:
   --strand <Forward|Reverse> Strand specificity           [default: Forward]
   --bam                     Output sorted BAM file
   --no-bam                  Do not output BAM (default)
+  --                        Pass all following arguments verbatim to STAR
   -h, --help                Show this help
 EOF
 }


### PR DESCRIPTION
# Pass extra arguments to STAR + bump to v4.2

## Summary

Adds a `--` passthrough so users can hand arbitrary flags to the underlying
`STAR` command on any platform, bumps the CLI version to **4.2**, and enables
registry-backed Docker layer caching in the tag-release workflow.

Base: `main` ← Compare: `dev`

## Motivation

Previously the CLI only exposed a fixed set of options; any STAR parameter it
didn't wrap (e.g. `--outFilterScoreMin`, extra `--soloFeatures`) could not be
set without editing the platform scripts. This adds an escape hatch without
having to surface every STAR flag individually.

## Changes

### `--` passthrough to STAR (all platforms)

- Everything after a `--` sentinel on the command line is forwarded verbatim to
  `STAR`, appended after the built-in flags.
- Carried as a global bash array (`STAR_EXTRA_ARGS`) rather than a string, so
  each token is preserved exactly — values containing spaces are not
  word-split, and globs are not expanded.
- Empty-array expansion (`"${STAR_EXTRA_ARGS[@]}"`) is safe under
  `set -euo pipefail` on bash 4.4+ (CI/host is 5.1).

Usage:

```bash
starsolo 10x /data/fastqs SAMPLE1 --species human -- --outFilterScoreMin 20 --soloFeatures Gene GeneFull SJ
```

Files:
- `bin/starsolo` — init `STAR_EXTRA_ARGS=()` in `parse_droplet_args`; add the
  `--)` case that captures the remaining args and breaks.
- `lib/platform_10x.sh` — append to both PE and SE STAR invocations.
- `lib/platform_{dropseq,smartseq,rhapsody,indrops,strt}.sh` — append to each
  STAR invocation.

### Version bump

- `STARSOLO_VERSION` and header comment in `bin/starsolo` → **4.2**.

### Docs

- `README.md` — new "Passing extra options to STAR" section, `--` row added to
  the Global options table.

### CI

- `.github/workflows/quay-on-tag.yml` — add `cache-from`/`cache-to`
  (registry + GHA) to the Docker build/push step to speed up image builds.

## Notes for reviewers

- Passthrough args are **appended** after the CLI's own flags. A user can
  override defaults where STAR allows repeated flags, but STAR will error if a
  passed option is genuinely incompatible with a built-in one — this surfaces as
  a STAR error, not a friendly `starsolo` message. This is the expected tradeoff
  for a raw passthrough.
- `--` must come last, after all `starsolo` options.

## Testing

- `bash -n` passes on `bin/starsolo` and all `lib/platform_*.sh`.
- `starsolo --version` → `starsolo v4.2`.
- Parser verified to split built-in flags from passthrough args correctly,
  including multi-value flags and space-containing values.
